### PR TITLE
pass event's user to script context

### DIFF
--- a/api/core/script/script.exec.js
+++ b/api/core/script/script.exec.js
@@ -8,14 +8,15 @@ module.exports = function(options) {
 
     return gladys.script.getById({id})
         .then(function(script) {
-            return execCode(script.text);
+            return execCode(script.text, options.scope.user);
         });
 };
 
 // execute the code
-function execCode(code) {
+function execCode(code, user) {
     return new Promise(function(resolve, reject) {
         try {
+            shared.sandbox.user = user;
             var script = new vm.Script(code, sails.config.scripts.vmOptions);
             script.runInNewContext(shared.sandbox);
             resolve();


### PR DESCRIPTION
So that you can use user id in script by calling user variable.
This can be usefull when you want to retreive user's information in a script relative to one specific user without applying conditions to this specific user.

For example:
I want Gladys says "Hello _name_" when any user enter's the home and I don't want to have N scripts with N  conditions "if user == _name_"